### PR TITLE
Remove dead users route and action

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,17 +18,6 @@ class UsersController < ApplicationController
     render json: { user: @user }
   end
 
-  # POST /users
-  def create
-    @user = User.new(user_params)
-
-    if @user.save
-      render json: @user, status: :created, location: @user
-    else
-      render json: @user.errors, status: :unprocessable_entity
-    end
-  end
-
   # PATCH/PUT /users/1
   def update
     if @user.update(user_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,12 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { sessions: 'sessions' }, defaults: { format: :json }
   get 'users/me' => 'users#me', as: 'current_user'
   resources :alerts
-  resources :users do
+  resources :users, except: :create do
     resources :teams
   end
 
   resources :teams do
-    resources :users
+    resources :users, except: :create
     resources :alerts
   end
 end


### PR DESCRIPTION
There are two routes defined for the same pattern of `POST
/users`. Devise's route is the one that is currently winning, so it
should be safe to remove the other one and its corresponding action.

Before:

```
$ bundle exec rake routes | grep "POST   /users("
POST   /users(.:format)    devise/registrations#create {:format=>:json}
POST   /users(.:format)    users#create
```

After:

```
$ bundle exec rake routes | grep "POST   /users("`
POST   /users(.:format)    devise/registrations#create {:format=>:json}
```

I also removed the route nested under teams, which is not technically
dead but I don't believe it is being used.
