### PR TITLE
Authorize user access by teams

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,10 +8,11 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
-    @users = User.joins(:teams).where(:teams => {:id => current_user.teams})
-    @team = Team.find(params["team_id"]) if params["team_id"]
+    teams = current_user.teams
+    teams = teams.where(:id => params["team_id"]) if params["team_id"]
+    @users = User.joins(:teams).where(:teams => {:id => teams})
 
-    render json: @team ? @team.users : @users
+    render json: @users
   end
 
   # GET /users/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,11 @@ class UsersController < ApplicationController
 
   # GET /users/1
   def show
-    render json: @user
+    if (current_user.teams & @user.teams).any?
+      render json: @user
+    else
+      head :forbidden
+    end
   end
 
   # PATCH/PUT /users/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,12 +8,16 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
-    @users = if params["team_id"]
-               current_user.teammates(params["team_id"])
-             else
-               current_user.teammates
-             end
-    render json: @users
+    if params["team_id"]
+      team = Team.find(params["team_id"])
+      if current_user.teams.include?(team)
+        render json: team.users
+      else
+        head :forbidden
+      end
+    else
+      render json: current_user.teammates
+    end
   end
 
   # GET /users/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
-    @users = User.all
+    @users = User.joins(:teams).where(:teams => {:id => current_user.teams})
     @team = Team.find(params["team_id"]) if params["team_id"]
 
     render json: @team ? @team.users : @users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,10 +8,11 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
-    teams = current_user.teams
-    teams = teams.where(:id => params["team_id"]) if params["team_id"]
-    @users = User.joins(:teams).where(:teams => {:id => teams})
-
+    @users = if params["team_id"]
+               current_user.teammates(params["team_id"])
+             else
+               current_user.teammates
+             end
     render json: @users
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,10 +18,8 @@ class User < ApplicationRecord
     end
   end
 
-  def teammates(team_id = nil)
-    ts = teams
-    ts = ts.where(:id => team_id) if team_id
-    self.class.on_teams(ts)
+  def teammates
+    self.class.on_teams(teams)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,20 @@ class User < ApplicationRecord
 
   before_save :ensure_authentication_token
 
+  def self.on_teams(teams)
+    joins(:teams).where(:teams => {:id => teams})
+  end
+
   def ensure_authentication_token
     if authentication_token.blank?
       self.authentication_token = generate_authentication_token
     end
+  end
+
+  def teammates(team_id = nil)
+    ts = teams
+    ts = ts.where(:id => team_id) if team_id
+    self.class.on_teams(ts)
   end
 
   private

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,10 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-alice: {email: alice@example.com}
-# column: value
-#
-bob: {email: bob@example.com}
-# column: value
+alice:
+  email: alice@example.com
+  teams: [one]
+
+bob:
+  email: bob@example.com
+  teams: [one]

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,3 +11,7 @@ alice:
 bob:
   email: bob@example.com
   teams: [one]
+
+carol:
+  email: carol@example.com
+  teams: [two]

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -16,8 +16,6 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
   end
 
   test "should create user" do
-    sign_in users(:alice)
-
     assert_difference('User.count') do
       params = {
         user: {

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -3,11 +3,15 @@ require 'test_helper'
 class UserFlowsTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test "should get index" do
+  test "should get index of users on the requester's teams" do
     sign_in users(:alice)
 
     get users_url, as: :json
 
+    ids = response.parsed_body["data"].map { |u| u["id"] }
+    assert_includes(ids, users(:alice).id.to_s)
+    assert_includes(ids, users(:bob).id.to_s)
+    assert_not_includes(ids, users(:carol).id)
     assert_response :success
   end
 

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -28,13 +28,20 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     assert_response 201
   end
 
-  test "should show user" do
-    user = users(:alice)
-    sign_in user
+  test "should show user if on the same team" do
+    sign_in users(:alice)
 
-    get user_url(user), as: :json
+    get user_url(users(:bob)), as: :json
 
     assert_response :success
+  end
+
+  test "should not show user from a different team" do
+    sign_in users(:alice)
+
+    get user_url(users(:carol)), as: :json
+
+    assert_response :forbidden
   end
 
   test "should not show user unless logged in" do

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -17,7 +17,7 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     assert_difference('User.count') do
       params = {
         user: {
-          email: "carol@example.com",
+          email: "wendy@example.com",
           password: "password",
           password_confirmation: "password"
         }

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -15,6 +15,27 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should get index of users scoped to specific team" do
+    sign_in users(:bob)
+
+    get team_users_url(teams(:one)), as: :json
+
+    ids = response.parsed_body["data"].map { |u| u["id"] }
+    assert_includes(ids, users(:alice).id.to_s)
+    assert_includes(ids, users(:bob).id.to_s)
+    assert_not_includes(ids, users(:carol).id.to_s)
+    assert_response :success
+  end
+
+  test "should not get index of other team's users" do
+    sign_in users(:alice)
+
+    get team_users_url(teams(:two)), as: :json
+
+    assert_empty(response.parsed_body["data"])
+    assert_response :success
+  end
+
   test "should create user" do
     assert_difference('User.count') do
       params = {

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -32,8 +32,7 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
 
     get team_users_url(teams(:two)), as: :json
 
-    assert_empty(response.parsed_body["data"])
-    assert_response :success
+    assert_response :forbidden
   end
 
   test "should create user" do


### PR DESCRIPTION
Adds some stuff to enforce the rules outlined in this comment: https://github.com/lbaillie/assemble/pull/9#discussion_r102251639.

@lbaillie i hope I am understanding this correctly! I did not add any enforcement of filtering when using the nested route, i.e. `GET teams/:team_id/users` to ensure that the requester is on the requested team. But I can add that....just didn't want to get carried away with this PR before getting some feedback. Thanks!