### PR TITLE
JSON API updates

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -17,7 +17,8 @@ class AlertsController < ApplicationController
 
   # POST /alerts
   def create
-    @alert = Alert.new(alert_params["alert"])
+    team = Team.find(params[:team_id])
+    @alert = team.alerts.new(alert_params)
 
     if @alert.save
       render json: @alert, status: :created, location: @alert
@@ -28,7 +29,7 @@ class AlertsController < ApplicationController
 
   # PATCH/PUT /alerts/1
   def update
-    if @alert.update(alert_params["alert"])
+    if @alert.update(alert_params)
       render json: @alert
     else
       render json: @alert.errors, status: :unprocessable_entity
@@ -48,6 +49,9 @@ class AlertsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def alert_params
-      params.permit(alert: [:alert_text, :team_id, :alert_location])
+      ActiveModelSerializers::Deserialization.jsonapi_parse(
+        params,
+        only: [:"alert-text", :"alert-location"]
+      )
     end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -3,7 +3,7 @@ class TeamsController < ApplicationController
 
   # GET /teams
   def index
-    @user = User.find(team_params["user_id"]) if team_params["user_id"]
+    @user = User.find(params["user_id"]) if params["user_id"]
     @teams = @user ? @user.teams : Team.all
 
     render json: @teams
@@ -47,6 +47,9 @@ class TeamsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def team_params
-      params.permit(:team_name, :user_id)
+      ActiveModelSerializers::Deserialization.jsonapi_parse(
+        params,
+        only: [:"team-name", :user_id]
+      )
     end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -49,7 +49,7 @@ class TeamsController < ApplicationController
     def team_params
       ActiveModelSerializers::Deserialization.jsonapi_parse(
         params,
-        only: [:"team-name", :user_id]
+        only: [:"team-name"]
       )
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,6 +55,9 @@ class UsersController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def user_params
-      params.require(:user).permit(:email, :username, :profile_text, :team_id, :provider, :uid)
+      params
+        .require(:data)
+        .require(:attributes)
+        .permit(:email, :username, :profile_text, :team_id, :provider, :uid)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
     def user_params
       ActiveModelSerializers::Deserialization.jsonapi_parse(
         params,
-        only: [:email, :username, :"profile-text", :team_id, :provider, :uid]
+        only: [:email, :username, :"profile-text", :provider, :uid]
       )
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,9 +55,9 @@ class UsersController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def user_params
-      params
-        .require(:data)
-        .require(:attributes)
-        .permit(:email, :username, :profile_text, :team_id, :provider, :uid)
+      ActiveModelSerializers::Deserialization.jsonapi_parse(
+        params,
+        only: [:email, :username, :"profile-text", :team_id, :provider, :uid]
+      )
     end
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,8 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register(
+  'application/vnd.api+json',
+  :json,
+  %w(application/vnd.api+json text/x-json application/json)
+)

--- a/test/controllers/alerts_controller_test.rb
+++ b/test/controllers/alerts_controller_test.rb
@@ -15,10 +15,10 @@ class AlertsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create alert" do
-    params = { alert: { alert_text: "There's an alert going on", team_id: @team.id } }
+    params = { data: { attributes: { alert_text: "There's an alert going on" } } }
 
     assert_difference('Alert.count') do
-      post alerts_url, params: params, as: :json
+      post team_alerts_url(@team), params: params, as: :json
     end
 
     assert_response 201
@@ -30,7 +30,7 @@ class AlertsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update alert" do
-    patch alert_url(@alert), params: { alert: { alert_text: @alert.alert_text } }, as: :json
+    patch alert_url(@alert), params: { data: { attributes: { alert_text: @alert.alert_text } } }, as: :json
     assert_response 200
   end
 

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -41,7 +41,11 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update team" do
-    patch team_url(@team), params: { team: { team_name: @team.team_name } }, as: :json
+    patch team_url(@team), params: { data: { attributes: { "team-name" => "New Team Name" } } }, as: :json
+
+    actual = response.parsed_body["data"]["attributes"]["team-name"]
+    expected = "New Team Name"
+    assert_equal(expected, actual)
     assert_response 200
   end
 

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -29,7 +29,7 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create team" do
     assert_difference('Team.count') do
-      post teams_url, params: { team: { team_name: @team.team_name } }, as: :json
+      post teams_url, params: { data: { attributes: { team_name: @team.team_name } } }, as: :json
     end
 
     assert_response 201

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,12 +6,15 @@
 #
 alice:
   email: alice@example.com
+  profile_text: "This is Alice's profile"
   teams: [one]
 
 bob:
   email: bob@example.com
+  profile_text: "This is Bob's profile"
   teams: [one]
 
 carol:
   email: carol@example.com
+  profile_text: "This is Carol's profile"
   teams: [two]

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -100,6 +100,23 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     assert_response 200
   end
 
+  test "should accept dash-case when updating" do
+    user = users(:alice)
+    sign_in user
+
+    patch(
+      user_url(user),
+      params: { data: { attributes: { "profile-text" => "This is Alice's updated profile" } } },
+      headers: { "CONTENT-TYPE" => "application/vnd.api+json" },
+      as: :json
+    )
+
+    actual = response.parsed_body["data"]["attributes"]["profile-text"]
+    expected = "This is Alice's updated profile"
+    assert_equal(expected, actual)
+    assert_response 200
+  end
+
   test "should not be able to update other user" do
     alice = users(:alice)
     bob = users(:bob)

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -78,7 +78,13 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     user = users(:alice)
     sign_in user
 
-    patch user_url(user), params: { data: { attributes: { email: "new.email@example.com" } } }, as: :json
+    patch(
+      user_url(user),
+      params: { data: { attributes: { email: "new.email@example.com" } } },
+      headers: { "CONTENT-TYPE" => "application/vnd.api+json" },
+      as: :json
+    )
+
     assert_equal "new.email@example.com", response.parsed_body["data"]["attributes"]["email"]
     assert_response 200
   end
@@ -88,7 +94,12 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     bob = users(:bob)
     sign_in alice
 
-    patch user_url(bob), params: { data: { attributes: { email: "new.email@example.com" } } }, as: :json
+    patch(
+      user_url(bob),
+      params: { data: { attributes: { email: "new.email@example.com" } } },
+      headers: { "CONTENT-TYPE" => "application/vnd.api+json" },
+      as: :json
+    )
 
     assert_response :forbidden
   end

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -50,6 +50,17 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     assert_response 201
   end
 
+  test "should transform keys to dash-case" do
+    sign_in users(:alice)
+
+    get user_url(users(:alice)), as: :json
+
+    actual = response.parsed_body["data"]["attributes"]["profile-text"]
+    expected = "This is Alice's profile"
+    assert_equal(expected, actual)
+    assert_response :success
+  end
+
   test "should show user if on the same team" do
     sign_in users(:alice)
 

--- a/test/integration/user_flows_test.rb
+++ b/test/integration/user_flows_test.rb
@@ -78,7 +78,7 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     user = users(:alice)
     sign_in user
 
-    patch user_url(user), params: { user: { email: "new.email@example.com" } }, as: :json
+    patch user_url(user), params: { data: { attributes: { email: "new.email@example.com" } } }, as: :json
     assert_equal "new.email@example.com", response.parsed_body["data"]["attributes"]["email"]
     assert_response 200
   end
@@ -88,7 +88,7 @@ class UserFlowsTest < ActionDispatch::IntegrationTest
     bob = users(:bob)
     sign_in alice
 
-    patch user_url(bob), params: { user: { email: "new.email@example.com" } }, as: :json
+    patch user_url(bob), params: { data: { attributes: { email: "new.email@example.com" } } }, as: :json
 
     assert_response :forbidden
   end


### PR DESCRIPTION
A couple of updates to ensure that:

* users can be updated with the proper JSON API format
* the 'application/vnd.api+json' mimetype is registered so that JSON API requests get properly deserialized and inserted into the `params`

There is probably similar work to be done on the teams controller but I might try to do that in a follow up if that's OK (I'll need to write tests for that and this is the only change that's required by my current work on the user profile stuff)