### PR TITLE
Forbid access to a team if a user is not on it

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,7 +11,11 @@ class TeamsController < ApplicationController
 
   # GET /teams/1
   def show
-    render json: @team
+    if @team.users.include?(current_user)
+      render json: @team
+    else
+      head :forbidden
+    end
   end
 
   # POST /teams

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -35,8 +35,11 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     assert_response 201
   end
 
-  test "should show team" do
+  test "should show team if user is on that team" do
     get team_url(@team), as: :json
+
+    assert_equal(@team.id.to_s, response.parsed_body["data"]["id"])
+    assert_equal("Team The First", response.parsed_body["data"]["attributes"]["team-name"])
     assert_response :success
   end
 

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -43,6 +43,12 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should not show team if user is not on that team" do
+    get team_url(teams(:two)), as: :json
+
+    assert_response :forbidden
+  end
+
   test "should update team" do
     patch team_url(@team), params: { data: { attributes: { "team-name" => "New Team Name" } } }, as: :json
 

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  team_name: MyString
+  team_name: Team The First
 
 two:
-  team_name: MyString
+  team_name: Team The Second


### PR DESCRIPTION
Fixes https://github.com/lbaillie/assemble-api/issues/15

@lbaillie it seems like it might be appropriate to also fix the index action (which I could optionally) do as part of this PR) but wanted to check first:

1. `GET /teams` currently returns the list of all teams - do we want to filter this to be only the teams which the user is on?
2. `GET /users/:user_id/teams` similarly will return the list of teams a user is on for any user. Is there a use case for this? I am wondering if we are only concerned with the current user's teams, maybe this route is not necessary?